### PR TITLE
Bumps Awesome-Lint to v0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you want to publish a _fix_ for the current version, you may bump the micro s
 
 ### Linting / Continuous Integration
 
-Automatic linting is performed against [awesome-lint](https://github.com/sindresorhus/awesome-lint) on [Travis](https://github.com/HorlogeSkynet/awesome-thinkerview/releases).  
+Automatic linting is performed against [awesome-lint](https://github.com/sindresorhus/awesome-lint) on [Travis](https://travis-ci.org/).  
 Please try to run it locally before submitting any changes : `npm run test`.
 
 <!--lint ignore awesome-no-ci-badge-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,27 +4,27 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-			"integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.10.1"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-			"integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-			"integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.1",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
@@ -67,9 +67,9 @@
 			"dev": true
 		},
 		"@types/glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -89,9 +89,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.11",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",
-			"integrity": "sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -218,9 +218,9 @@
 			"dev": true
 		},
 		"awesome-lint": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/awesome-lint/-/awesome-lint-0.13.0.tgz",
-			"integrity": "sha512-IBK7q6yrCJoGa835c9PmmbxiqRiI2zb0IvsAbo6Xrc2u0sZdB1e1PDombua+emdfgyp50szgVWtg6VBBp/i2Ag==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/awesome-lint/-/awesome-lint-0.15.1.tgz",
+			"integrity": "sha512-zOUeGfqTHo8yowJbc+y0miREqDXfnG1529ocvN2OD4AcRy5uKDPRMitmRTR3+aYTbHSdbI9fhKfbseoPO2uoyA==",
 			"dev": true,
 			"requires": {
 				"arrify": "^2.0.1",
@@ -248,6 +248,7 @@
 				"remark-lint-code-block-style": "^2.0.0",
 				"remark-lint-definition-case": "^2.0.0",
 				"remark-lint-definition-spacing": "^2.0.0",
+				"remark-lint-double-link": "^0.1.0",
 				"remark-lint-emphasis-marker": "^2.0.0",
 				"remark-lint-fenced-code-marker": "^2.0.0",
 				"remark-lint-file-extension": "^1.0.2",
@@ -439,9 +440,9 @@
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -462,9 +463,9 @@
 			"dev": true
 		},
 		"camelcase": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-			"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
 		"camelcase-keys": {
@@ -476,14 +477,6 @@
 				"camelcase": "^5.3.1",
 				"map-obj": "^4.0.0",
 				"quick-lru": "^4.0.1"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				}
 			}
 		},
 		"case": {
@@ -566,9 +559,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
-			"integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+			"integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
 			"dev": true
 		},
 		"clone": {
@@ -866,9 +859,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -877,9 +870,9 @@
 			}
 		},
 		"eslint-rule-docs": {
-			"version": "1.1.193",
-			"resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.193.tgz",
-			"integrity": "sha512-LhMUMMEPK3X/gTyU3wrpeVoc479n7gOPn1oaIhX1mxdZW6MIfFqB84we+bVivKk1Q9Z00tlD72KMEwzazz/ivQ==",
+			"version": "1.1.209",
+			"resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.209.tgz",
+			"integrity": "sha512-a0mg7IWKvV47HEuMLdk91Qq+cMl7BPUQ1WHtAk6XfSNqdWsm9Zfx4DptHWWZ2XcaGowIflO6tIv9nM8fLFZRcQ==",
 			"dev": true
 		},
 		"execa": {
@@ -1353,9 +1346,9 @@
 			}
 		},
 		"ip-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-			"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+			"integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
 			"dev": true
 		},
 		"irregular-plurals": {
@@ -1612,10 +1605,10 @@
 			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
 			"dev": true
 		},
-		"json-parse-better-errors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
 		"keyv": {
@@ -1739,18 +1732,16 @@
 			"dev": true
 		},
 		"meow": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-			"integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+			"integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
 			"dev": true,
 			"requires": {
 				"@types/minimist": "^1.2.0",
-				"arrify": "^2.0.1",
-				"camelcase": "^6.0.0",
 				"camelcase-keys": "^6.2.2",
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
-				"minimist-options": "^4.0.2",
+				"minimist-options": "4.1.0",
 				"normalize-package-data": "^2.5.0",
 				"read-pkg-up": "^7.0.1",
 				"redent": "^3.0.0",
@@ -1982,18 +1973,18 @@
 			}
 		},
 		"onetime": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
 		},
 		"ora": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
-			"integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^3.0.0",
@@ -2048,9 +2039,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -2115,14 +2106,14 @@
 			"dev": true
 		},
 		"parse-json": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-			"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+			"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1",
+				"json-parse-even-better-errors": "^2.3.0",
 				"lines-and-columns": "^1.1.6"
 			}
 		},
@@ -2288,9 +2279,9 @@
 			}
 		},
 		"remark": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-12.0.0.tgz",
-			"integrity": "sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==",
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz",
+			"integrity": "sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==",
 			"dev": true,
 			"requires": {
 				"remark-parse": "^8.0.0",
@@ -2299,18 +2290,18 @@
 			}
 		},
 		"remark-lint": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint/-/remark-lint-7.0.0.tgz",
-			"integrity": "sha512-OLrWPYy0MUcGLa/2rjuy1kQILTRRK+JiRtyUzqe4XRoHboGuvFDcy/W2e7sq5hu/0xmD+Eh7cEa1Coiqp7LeaA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint/-/remark-lint-7.0.1.tgz",
+			"integrity": "sha512-caZXo3qhuBxzvq9JSJFVQ/ERDq/6TJVgWn0KDwKOIJCGOuLXfQhby5XttUq+Rn7kLbNMtvwfWHJlte14LpaeXQ==",
 			"dev": true,
 			"requires": {
 				"remark-message-control": "^6.0.0"
 			}
 		},
 		"remark-lint-blockquote-indentation": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-2.0.0.tgz",
-			"integrity": "sha512-Ma/lk+egYzvzV9+RLxR7iaNcFqwsF02guxY2nFF7gaVFXWDhbRy+hbiRZiTQe3y8AK+smc2yE79I+JRUVL15LQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-2.0.1.tgz",
+			"integrity": "sha512-uJ9az/Ms9AapnkWpLSCJfawBfnBI2Tn1yUsPNqIFv6YM98ymetItUMyP6ng9NFPqDvTQBbiarulkgoEo0wcafQ==",
 			"dev": true,
 			"requires": {
 				"mdast-util-to-string": "^1.0.2",
@@ -2322,9 +2313,9 @@
 			}
 		},
 		"remark-lint-checkbox-character-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-2.0.0.tgz",
-			"integrity": "sha512-V+eTXFHrHCpFFG2RWaQM6lSetLLvpYC8WEZ9dMYSAUbeS/h0PhA7cB7j5kGH86RUwGCihawfzNAKbRmgGxL+DQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-2.0.1.tgz",
+			"integrity": "sha512-ANs1HaNOEYmc+O9Xyew7HRA48VXPnk7VLM76fLEf6bifXZU+VAJe+a6cmS+ohTSVSTjkMDl9dnbqiWQRE1U4zg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2335,9 +2326,9 @@
 			}
 		},
 		"remark-lint-checkbox-content-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-checkbox-content-indent/-/remark-lint-checkbox-content-indent-2.0.0.tgz",
-			"integrity": "sha512-02Xytexe8nso1ofPC6wN3FE48302nmteSIwydeIDFhJq7mG14SxF4xgay+Kjbhs/O5NoRIF2ju9qcPNJ5gFsXA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-checkbox-content-indent/-/remark-lint-checkbox-content-indent-2.0.1.tgz",
+			"integrity": "sha512-NYOLJK8G/8BMQmhnstBjlZYmiH+xj1ECVWAGndRG5cRYmFZL87FVEm44Jd57VKczIAHPkOp8rn8fPpVgvghjAw==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2348,9 +2339,9 @@
 			}
 		},
 		"remark-lint-code-block-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-2.0.0.tgz",
-			"integrity": "sha512-bXT1b9MvYDxKdLfzWTW3eSXWy7v57LXtU5ySLzlD1g3DWoSA6rSWjJT5l/2mA+iOuswg18ssY3SSjwExmTyWUA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-2.0.1.tgz",
+			"integrity": "sha512-eRhmnColmSxJhO61GHZkvO67SpHDshVxs2j3+Zoc5Y1a4zQT2133ZAij04XKaBFfsVLjhbY/+YOWxgvtjx2nmA==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2360,9 +2351,9 @@
 			}
 		},
 		"remark-lint-definition-case": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-definition-case/-/remark-lint-definition-case-2.0.0.tgz",
-			"integrity": "sha512-HU9lit5VSHJFPF6VJKR2oqFLZ75Jf6yNZIoqQsnQVTIW7HWn4hI1BTzytZOCA0LW/ZAtIGUpN4rIXg+pEibbeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-definition-case/-/remark-lint-definition-case-2.0.1.tgz",
+			"integrity": "sha512-M+XlThtQwEJLQnQb5Gi6xZdkw92rGp7m2ux58WMw/Qlcg02WgHR/O0OcHPe5VO5hMJrtI+cGG5T0svsCgRZd3w==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2372,9 +2363,9 @@
 			}
 		},
 		"remark-lint-definition-spacing": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-definition-spacing/-/remark-lint-definition-spacing-2.0.0.tgz",
-			"integrity": "sha512-kE+ffEGsyxgUDlcKSVrnhqyHjQfH0RtUVN/OdA/iSzKfTy/Yc9VMMaNu6xT14xhwjTnSVPrd38rUOnDt1LZhAw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-definition-spacing/-/remark-lint-definition-spacing-2.0.1.tgz",
+			"integrity": "sha512-xK9DOQO5MudITD189VyUiMHBIKltW1oc55L7Fti3i9DedXoBG7Phm+V9Mm7IdWzCVkquZVgVk63xQdqzSQRrSQ==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2383,10 +2374,27 @@
 				"unist-util-visit": "^2.0.0"
 			}
 		},
+		"remark-lint-double-link": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/remark-lint-double-link/-/remark-lint-double-link-0.1.3.tgz",
+			"integrity": "sha512-0zHUJimo0fNAqQPzwt6ii9pRYCxBU0wqilVlily1RxRyTqhy0ANgTQOERMaf+lkTEN1ADEeoyh9gE7VWzqI+WA==",
+			"dev": true,
+			"requires": {
+				"normalize-url": "^5.1.0"
+			},
+			"dependencies": {
+				"normalize-url": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.2.1.tgz",
+					"integrity": "sha512-bFT2ilr7p37ZPEQ9LO9HP/tdFIAE7Q4UoeojXNKeLjs0vXxZetM+C2K9jdbVS7b6ut66CflVLgk1yqHJVrXmiw==",
+					"dev": true
+				}
+			}
+		},
 		"remark-lint-emphasis-marker": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-2.0.0.tgz",
-			"integrity": "sha512-O7/8xeie/dkazeSjty+kxQ5n3kxw+YjeK81F3lbZ88J8L7bRIK4q84hTB2bzeHddOmX8zRzwvw8Y+BNesBU2/g==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-2.0.1.tgz",
+			"integrity": "sha512-7mpbAUrSnHiWRyGkbXRL5kfSKY9Cs8cdob7Fw+Z02/pufXMF4yRWaegJ5NTUu1RE+SKlF44wtWWjvcIoyY6/aw==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2396,9 +2404,9 @@
 			}
 		},
 		"remark-lint-fenced-code-marker": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-2.0.0.tgz",
-			"integrity": "sha512-ZkJ4/o0A34nQefhsu6AU2cftQjCwzXClbZ5TrwgtkQQHG9BSu9/vo3PSLxGGw7XBX63oKcrx5HWGrWXaeLTN2g==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-2.0.1.tgz",
+			"integrity": "sha512-lujpjm04enn3ma6lITlttadld6eQ1OWAEcT3qZzvFHp+zPraC0yr0eXlvtDN/0UH8mrln/QmGiZp3i8IdbucZg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2408,27 +2416,27 @@
 			}
 		},
 		"remark-lint-file-extension": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/remark-lint-file-extension/-/remark-lint-file-extension-1.0.4.tgz",
-			"integrity": "sha512-Zfp1mXNwpg7STjTWynZjL+/JtvIOCrmOAZzL3uK+tYpT0ZDPdQ1EQEl5D92+Eiu5OcYlenzG42jiLcyJjv+Q2g==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/remark-lint-file-extension/-/remark-lint-file-extension-1.0.5.tgz",
+			"integrity": "sha512-oVQdf5vEomwHkfQ7R/mgmsWW2H/t9kSvnrxtVoNOHr+qnOEafKKDn+AFhioN2kqtjCZBAjSSrePs6xGKmXKDTw==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-final-newline": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/remark-lint-final-newline/-/remark-lint-final-newline-1.0.4.tgz",
-			"integrity": "sha512-pUwqX8TVTTfqX5arMnu9Dr2ufg6wZ6Pk1VeqlnWfK92PBXLG8Zc3yrLpYXOJy1fHdWpqUECRRowG0H/OkZIEbw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/remark-lint-final-newline/-/remark-lint-final-newline-1.0.5.tgz",
+			"integrity": "sha512-rfLlW8+Fz2dqnaEgU4JwLA55CQF1T4mfSs/GwkkeUCGPenvEYwSkCN2KO2Gr1dy8qPoOdTFE1rSufLjmeTW5HA==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-hard-break-spaces": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-hard-break-spaces/-/remark-lint-hard-break-spaces-2.0.0.tgz",
-			"integrity": "sha512-dmB8GucOSDtEctwa+Y8JlSAWF4q8HcquvLr+OpFOSE1QCrpFoZdb2mcSY+rZuTtfeg4S60orhhzArd2aiHvUPQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-hard-break-spaces/-/remark-lint-hard-break-spaces-2.0.1.tgz",
+			"integrity": "sha512-Qfn/BMQFamHhtbfLrL8Co/dbYJFLRL4PGVXZ5wumkUO5f9FkZC2RsV+MD9lisvGTkJK0ZEJrVVeaPbUIFM0OAw==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2438,9 +2446,9 @@
 			}
 		},
 		"remark-lint-heading-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-2.0.0.tgz",
-			"integrity": "sha512-LZvnAq5zWh9i/oRAEocth8yajEEH4kRgCrL4dE547Nkv6zaR2SKcym+uXMZ+GF6WEWcjXMiwSxIL7MHaT6XexA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-2.0.1.tgz",
+			"integrity": "sha512-IrFLNs0M5Vbn9qg51AYhGUfzgLAcDOjh2hFGMz3mx664dV6zLcNZOPSdJBBJq3JQR4gKpoXcNwN1+FFaIATj+A==",
 			"dev": true,
 			"requires": {
 				"mdast-util-heading-style": "^1.0.2",
@@ -2450,9 +2458,9 @@
 			}
 		},
 		"remark-lint-link-title-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-2.0.0.tgz",
-			"integrity": "sha512-XQOHQmeVVizjbQtJ1vCWwqG0FkHlZUOhdt3Gj65NqRIuOWQepGzu9KnPcdACuyax4P9wKGFvOEWlLrlPlFseyg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-2.0.1.tgz",
+			"integrity": "sha512-+Q7Ew8qpOQzjqbDF6sUHmn9mKgje+m2Ho8Xz7cEnGIRaKJgtJzkn/dZqQM/az0gn3zaN6rOuwTwqw4EsT5EsIg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2463,9 +2471,9 @@
 			}
 		},
 		"remark-lint-list-item-bullet-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-2.0.0.tgz",
-			"integrity": "sha512-8iK+ht771UBf/Iuj4YBgdLnFFOyEgfXY62jBoywtMuiOLVWXDfPe+jUY7pCrnFjsnxXGEnMaxHJqENgrHd0J/w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-2.0.1.tgz",
+			"integrity": "sha512-tozDt9LChG1CvYJnBQH/oh45vNcHYBvg79ogvV0f8MtE/K0CXsM8EpfQ6pImFUdHpBV1op6aF6zPMrB0AkRhcQ==",
 			"dev": true,
 			"requires": {
 				"pluralize": "^8.0.0",
@@ -2476,9 +2484,9 @@
 			}
 		},
 		"remark-lint-list-item-content-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-2.0.0.tgz",
-			"integrity": "sha512-UO3c71SVW7cCYMuw630FOFI/5fc5ombw+Dxkw7snKsjI3Yrhkln8t6YycYc5Isa8qQu9I2JgD6PG2EMla8iNRQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-2.0.1.tgz",
+			"integrity": "sha512-OzUMqavxyptAdG7vWvBSMc9mLW9ZlTjbW4XGayzczd3KIr6Uwp3NEFXKx6MLtYIM/vwBqMrPQUrObOC7A2uBpQ==",
 			"dev": true,
 			"requires": {
 				"pluralize": "^8.0.0",
@@ -2489,9 +2497,9 @@
 			}
 		},
 		"remark-lint-list-item-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-list-item-indent/-/remark-lint-list-item-indent-2.0.0.tgz",
-			"integrity": "sha512-qnKsq2UQpCC8gnI1O23dgoKsd+5RAJrAJuvHXrlkRgzsab7BOMluptxRlyLVXn0P71l4Wo/bfo84Ual7qpOyWw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-list-item-indent/-/remark-lint-list-item-indent-2.0.1.tgz",
+			"integrity": "sha512-4IKbA9GA14Q9PzKSQI6KEHU/UGO36CSQEjaDIhmb9UOhyhuzz4vWhnSIsxyI73n9nl9GGRAMNUSGzr4pQUFwTA==",
 			"dev": true,
 			"requires": {
 				"pluralize": "^8.0.0",
@@ -2512,9 +2520,9 @@
 			}
 		},
 		"remark-lint-no-auto-link-without-protocol": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-2.0.0.tgz",
-			"integrity": "sha512-pIntUa+zNiyRxIt2Wvp1soktDbVnk1SEiJXsjcLYYn9GapgXqOQG5ZfFwR6zxTkGV5mZKo9927EvHQkvIV6cLQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-2.0.1.tgz",
+			"integrity": "sha512-TFcXxzucsfBb/5uMqGF1rQA+WJJqm1ZlYQXyvJEXigEZ8EAxsxZGPb/gOQARHl/y0vymAuYxMTaChavPKaBqpQ==",
 			"dev": true,
 			"requires": {
 				"mdast-util-to-string": "^1.0.2",
@@ -2525,9 +2533,9 @@
 			}
 		},
 		"remark-lint-no-blockquote-without-marker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-3.0.0.tgz",
-			"integrity": "sha512-auyAxMVDuhvGw29VilqUfUIUnBT7qmByG/kBPqV/GwM1a5rn4fIUJ7p9Je9BlWMRCBMTNQUMsm3ce0dawouVew==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-3.0.1.tgz",
+			"integrity": "sha512-sM953+u0zN90SGd2V5hWcFbacbpaROUslS5Q5F7/aa66/2rAwh6zVnrXc4pf7fFOpj7I9Xa8Aw+uB+3RJWwdrQ==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2538,9 +2546,9 @@
 			}
 		},
 		"remark-lint-no-emphasis-as-heading": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-emphasis-as-heading/-/remark-lint-no-emphasis-as-heading-2.0.0.tgz",
-			"integrity": "sha512-1POPqULVRC5zKczE3LJS+QGY8efLuFl+wdd/Q9xEULK42yEEiFHgZP4mlF6yi9rim5KgrIBMAoGPxJLXse2rPQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-emphasis-as-heading/-/remark-lint-no-emphasis-as-heading-2.0.1.tgz",
+			"integrity": "sha512-z86+yWtVivtuGIxIC4g9RuATbgZgOgyLcnaleonJ7/HdGTYssjJNyqCJweaWSLoaI0akBQdDwmtJahW5iuX3/g==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2586,54 +2594,54 @@
 			}
 		},
 		"remark-lint-no-file-name-articles": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-articles/-/remark-lint-no-file-name-articles-1.0.4.tgz",
-			"integrity": "sha512-Ieqg/2WjYs5M+IoZsFrQUG0niN8zRC6IAYWOVaHi3UK/1P0IdmXKZE6pCFSJrhletawAaPw9Xtl42/45tcccCA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-articles/-/remark-lint-no-file-name-articles-1.0.5.tgz",
+			"integrity": "sha512-AQk5eTb3s3TAPPjiglZgqlQj4ycao+gPs8/XkdN1VCPUtewW0GgwoQe7YEuBKayJ6ioN8dGP37Kg/P/PlKaRQA==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-no-file-name-consecutive-dashes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-consecutive-dashes/-/remark-lint-no-file-name-consecutive-dashes-1.0.4.tgz",
-			"integrity": "sha512-Fyc8mL+Fyt2b/BVkCc2Y+GjJ4SwafDKQEUaizeuZQDBTiqRK3S4L9YpvLHTAPgTNntZkXLUsHzFDlGyKzW2gBQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-consecutive-dashes/-/remark-lint-no-file-name-consecutive-dashes-1.0.5.tgz",
+			"integrity": "sha512-Mg2IDsi790/dSdAzwnBnsMYdZm3qC2QgGwqOWcr0TPABJhhjC3p8r5fX4MNMTXI5It7B7bW9+ImmCeLOZiXkLg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-no-file-name-irregular-characters": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-irregular-characters/-/remark-lint-no-file-name-irregular-characters-1.0.4.tgz",
-			"integrity": "sha512-TbqV5rl+5iX8A5th5AS6wlXQSN/SnUqevqOHb0D65AMIIYlDfMGinKpEZ3xy52pJYDiV+1Z8J7WjUg13lBsNpw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-irregular-characters/-/remark-lint-no-file-name-irregular-characters-1.0.5.tgz",
+			"integrity": "sha512-Oe5i99qNUKc2bxmiH421o5B/kqlf1dfjAxpHNLhi2X2dXE91zRGavrlRM/4f4oR0N9Bqb3qB9JZPyMPWrzu9XA==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-no-file-name-mixed-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-mixed-case/-/remark-lint-no-file-name-mixed-case-1.0.4.tgz",
-			"integrity": "sha512-kaUrUAZx7rw+PVKgENZ7/2//MIFoe3LxEkdIUoszPTvlEHdEtqCH3JAyxl9alwyhfs6KfCpCE3jLd84MfWfudg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-mixed-case/-/remark-lint-no-file-name-mixed-case-1.0.5.tgz",
+			"integrity": "sha512-ilrUCbHZin/ENwr8c3SC2chgkFsizXjBQIB/oZ7gnm1IkCkZPiMyXZAHdpwC/DjbrpGxfMYh9JmIHao4giS5+A==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-no-file-name-outer-dashes": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-outer-dashes/-/remark-lint-no-file-name-outer-dashes-1.0.5.tgz",
-			"integrity": "sha512-5CMrCqyJj4ydM2QMhMAc60o08fJDxBgmO62r+RqVs+aIdIK6TtsF+T8oX+aTEtc3y/euKJ681tqEsSeJZh/h0A==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-file-name-outer-dashes/-/remark-lint-no-file-name-outer-dashes-1.0.6.tgz",
+			"integrity": "sha512-rT8CmcIlenegS0Yst4maYXdZfqIjBOiRUY8j/KJkORF5tKH+3O1/S07025qPGmcRihzK3w4yO0K8rgkKQw0b9w==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0"
 			}
 		},
 		"remark-lint-no-heading-content-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-2.0.0.tgz",
-			"integrity": "sha512-Zqg0WXG60Nan8j7HZtnBXidMxXhlhc7Q5JrB54I3n7H3vSPCyaqhZJ2/obYVLalEVGND8NOJGvfA1rtchaZyYg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-2.0.1.tgz",
+			"integrity": "sha512-Jp0zCykGwg13z7XU4VuoFK7DN8bVZ1u3Oqu3hqECsH6LMASb0tW4zcTIc985kcVo3OQTRyb6KLQXL2ltOvppKA==",
 			"dev": true,
 			"requires": {
 				"mdast-util-heading-style": "^1.0.2",
@@ -2645,9 +2653,9 @@
 			}
 		},
 		"remark-lint-no-heading-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-heading-indent/-/remark-lint-no-heading-indent-2.0.0.tgz",
-			"integrity": "sha512-dBjSP2QdQVypFpwQdjZ6h/VsyY3CBY+IXY2edSWiITOofZrt7knmwrLFUoxPtvc9k4PIBA7XXpiwPPYBQzuLFg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-heading-indent/-/remark-lint-no-heading-indent-2.0.1.tgz",
+			"integrity": "sha512-eU4t3t8icfRzQlna74gQqNQ1Y9TuXZjNKriMBEmhLzyniHqcY4TO3pBmrkm2TJN/ji6gVBWjaT0uYO2Vm6KxLA==",
 			"dev": true,
 			"requires": {
 				"pluralize": "^8.0.0",
@@ -2658,9 +2666,9 @@
 			}
 		},
 		"remark-lint-no-heading-punctuation": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-heading-punctuation/-/remark-lint-no-heading-punctuation-2.0.0.tgz",
-			"integrity": "sha512-aJdMCKULB1G5NTEi1gprE7Z6OMgRWgH22sOIUbcMSO49tofy9tnYMRKIXG2qhvH7Jep9JTGuNsx03xJzDgJe9A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-heading-punctuation/-/remark-lint-no-heading-punctuation-2.0.1.tgz",
+			"integrity": "sha512-lY/eF6GbMeGu4cSuxfGHyvaQQBIq/6T/o+HvAR5UfxSTxmxZFwbZneAI2lbeR1zPcqOU87NsZ5ZZzWVwdLpPBw==",
 			"dev": true,
 			"requires": {
 				"mdast-util-to-string": "^1.0.2",
@@ -2670,9 +2678,9 @@
 			}
 		},
 		"remark-lint-no-inline-padding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-2.0.0.tgz",
-			"integrity": "sha512-0YueQ3SBA8zFQYCN0/afRc6ZuSbM4Azx4sPVeVpAfMT0MrYgmi6msswyhUDXaeN2RwVO6bx/ZW6di8dVqRr7UA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-2.0.1.tgz",
+			"integrity": "sha512-a36UlPvRrLCgxjjG3YZA9VCDvLBcoBtGNyM04VeCPz+d9hHe+5Fs1C/jL+DRLCH7nff90jJ5C/9b8/LTwhjaWA==",
 			"dev": true,
 			"requires": {
 				"mdast-util-to-string": "^1.0.2",
@@ -2682,9 +2690,9 @@
 			}
 		},
 		"remark-lint-no-multiple-toplevel-headings": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-multiple-toplevel-headings/-/remark-lint-no-multiple-toplevel-headings-2.0.0.tgz",
-			"integrity": "sha512-vpbdnrqUykyqpjaREg4W07J3gHgR0eTapDkz9RjVwyGNmBry7xUnyvaiPavAKqsA+qO/nnpIH8Qyw/2u5hDsJQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-multiple-toplevel-headings/-/remark-lint-no-multiple-toplevel-headings-2.0.1.tgz",
+			"integrity": "sha512-VKSItR6c+u3OsE5pUiSmNusERNyQS9Nnji26ezoQ1uvy06k3RypIjmzQqJ/hCkSiF+hoyC3ibtrrGT8gorzCmQ==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2706,9 +2714,9 @@
 			}
 		},
 		"remark-lint-no-shell-dollars": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-shell-dollars/-/remark-lint-no-shell-dollars-2.0.1.tgz",
-			"integrity": "sha512-N+wOq3nmZ8WnCreWhi/rfIKQJPAz+pcbErQATcnQzH0znzldXlX8Ovlm54yDx/A+TmGMex/epkCwuiewIj9m4g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-shell-dollars/-/remark-lint-no-shell-dollars-2.0.2.tgz",
+			"integrity": "sha512-zhkHZOuyaD3r/TUUkkVqW0OxsR9fnSrAnHIF63nfJoAAUezPOu8D1NBsni6rX8H2DqGbPYkoeWrNsTwiKP0yow==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2717,9 +2725,9 @@
 			}
 		},
 		"remark-lint-no-table-indentation": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-2.0.0.tgz",
-			"integrity": "sha512-5akpqHl+5r3Xe2WFiZB1I9eAwn6zTYqXNd0CVsiTF3DJo0KyvvgyrFRV1sCf/l/kzyNaFvpWpFDTMoWc8EI0RQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-2.0.1.tgz",
+			"integrity": "sha512-PnqIyg5qf+QbaIfolxXpakk/MR1RxZ0EdhKgVqsaEwv8+fka1LZYu7QO+ZFmrT82gVzvjRqHJkmxTskC/VP30w==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2729,9 +2737,9 @@
 			}
 		},
 		"remark-lint-no-undefined-references": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-2.0.0.tgz",
-			"integrity": "sha512-K4k05pmlMRqEMUDYewitRUx8zM+ntJWbG61dILmL7to7uy0JoSbzuDtz1cxC+kKBKzkulPnyE3WOgRZG8RX2Jg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-2.0.1.tgz",
+			"integrity": "sha512-tXM2ctFnduC3QcskrIePUajcjtNtBmo2dvlj4aoQJtQy09Soav/rYngb8u/SgERc6Irdmm5s55UAwR9CcSrzVg==",
 			"dev": true,
 			"requires": {
 				"collapse-white-space": "^1.0.4",
@@ -2741,9 +2749,9 @@
 			}
 		},
 		"remark-lint-no-unneeded-full-reference-image": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-unneeded-full-reference-image/-/remark-lint-no-unneeded-full-reference-image-2.0.0.tgz",
-			"integrity": "sha512-mGocJ71Pp5/Jf97RMt4dUcEPnbPJgn/9fvm6FXXMCG9INGNhM5UX252Zr2Al+4L9TQQmZhCt5osBrK34TGBTjw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-unneeded-full-reference-image/-/remark-lint-no-unneeded-full-reference-image-2.0.1.tgz",
+			"integrity": "sha512-ZqkrW6l/n1EmcGdtzBFoDygG2ehd/Wx46Id9Dagg15oLzwvbhp5mJIXArXU2qGrF82w1hfainCaZzyH/OBJtEg==",
 			"dev": true,
 			"requires": {
 				"collapse-white-space": "^1.0.0",
@@ -2753,9 +2761,9 @@
 			}
 		},
 		"remark-lint-no-unneeded-full-reference-link": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-unneeded-full-reference-link/-/remark-lint-no-unneeded-full-reference-link-2.0.0.tgz",
-			"integrity": "sha512-SrFhgShjxUwJmWHVuUvV41ekKEtszzhG+uiy/fKedH+53Ummie8naRYmlfVGVEAgz/wXrFBg4pdr8c3I11H+LA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-unneeded-full-reference-link/-/remark-lint-no-unneeded-full-reference-link-2.0.1.tgz",
+			"integrity": "sha512-OcPQiG6meVpvfydzxkxPdVc8jcXdklQW4gMjY2BevLtVoaIJ+dgNBPazyYHP/0EzpVY2RftD3CZ+5hiLW2rgpA==",
 			"dev": true,
 			"requires": {
 				"collapse-white-space": "^1.0.0",
@@ -2765,9 +2773,9 @@
 			}
 		},
 		"remark-lint-no-unused-definitions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-2.0.0.tgz",
-			"integrity": "sha512-Y8zrulwaf7z6WR1ICfEGjW92iq2SPEN7Zhrs0nloNITHOg22tIPf28TurUz9HSQ3sEd52d9bZCfW9RkdfMq1xw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-2.0.1.tgz",
+			"integrity": "sha512-+BMc0BOjc364SvKYLkspmxDch8OaKPbnUGgQBvK0Bmlwy42baR4C9zhwAWBxm0SBy5Z4AyM4G4jKpLXPH40Oxg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2776,9 +2784,9 @@
 			}
 		},
 		"remark-lint-ordered-list-marker-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-2.0.0.tgz",
-			"integrity": "sha512-zYMZA8tQD/slJYKqsstZv0/Q34Hkdlf4DjC8SOr92PSA60R/xr7JdVd/AHHisbMsFvdnHZrxaB8oIOtbAUJCSw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-2.0.1.tgz",
+			"integrity": "sha512-Cnpw1Dn9CHn+wBjlyf4qhPciiJroFOEGmyfX008sQ8uGoPZsoBVIJx76usnHklojSONbpjEDcJCjnOvfAcWW1A==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2788,9 +2796,9 @@
 			}
 		},
 		"remark-lint-ordered-list-marker-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-2.0.0.tgz",
-			"integrity": "sha512-5ASe7Bgb/npEuLvdQO9AtldVCEVCAKExGSqC3RJ7esy3rI5y8B0Jo383cvvCICVdQrHFIIlO3JAPhINSGNVfig==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-2.0.1.tgz",
+			"integrity": "sha512-blt9rS7OKxZ2NW8tqojELeyNEwPhhTJGVa+YpUkdEH+KnrdcD7Nzhnj6zfLWOx6jFNZk3jpq5nvLFAPteHaNKg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2800,9 +2808,9 @@
 			}
 		},
 		"remark-lint-rule-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-2.0.0.tgz",
-			"integrity": "sha512-fdRfLUE5AJiFEn9rWTQrHwOUG3UcYtIxbWnR7YFvuPlFmzcMRwRHP5ZOcrj4KIpwCdVtlPI3h08m0kfO7a1KlQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-2.0.1.tgz",
+			"integrity": "sha512-hz4Ff9UdlYmtO6Czz99WJavCjqCer7Cav4VopXt+yVIikObw96G5bAuLYcVS7hvMUGqC9ZuM02/Y/iq9n8pkAg==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2812,9 +2820,9 @@
 			}
 		},
 		"remark-lint-strong-marker": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-2.0.0.tgz",
-			"integrity": "sha512-1gl6vZF5BvV4kvS4xxhl8cw90La5Cio9ZFDQuspZMRA2KjzpwoU5RlTUbeHv8OqlKJJ2p7s0MDs8bLZNTzzjHA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-2.0.1.tgz",
+			"integrity": "sha512-8X2IsW1jZ5FmW9PLfQjkL0OVy/J3xdXLcZrG1GTeQKQ91BrPFyEZqUM2oM6Y4S6LGtxWer+neZkPZNroZoRPBQ==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2824,9 +2832,9 @@
 			}
 		},
 		"remark-lint-table-cell-padding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-2.0.0.tgz",
-			"integrity": "sha512-UstIXIaRVRJPKZPv1AXX/p3qCt//RYNsRHIq8KvL5YQPKaKWRkj2cNermCgm0XoUXy0EmRPNiBtUcuAQaP+jXg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-2.0.1.tgz",
+			"integrity": "sha512-vytUq4O1cg9UBXyeduANqpVqlbZpEtpXe/hYdvAObWgp1Jr7l74Zcvm+pn/ouaCuAsrxDVWeTa5Mg3V4OByw4g==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2836,9 +2844,9 @@
 			}
 		},
 		"remark-lint-table-pipe-alignment": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-table-pipe-alignment/-/remark-lint-table-pipe-alignment-2.0.0.tgz",
-			"integrity": "sha512-sml1Megf3Qgipd7Esi0nbD0+Jd/iyw3dtghp3G5NOmopS4yMg/fbriNbbWdwT1R+FfW/a3YORtes11ThVPRFKw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-table-pipe-alignment/-/remark-lint-table-pipe-alignment-2.0.1.tgz",
+			"integrity": "sha512-O89U7bp0ja6uQkT2uQrNB76GaPvFabrHiUGhqEUnld21yEdyj7rgS57kn84lZNSuuvN1Oor6bDyCwWQGzzpoOQ==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2848,9 +2856,9 @@
 			}
 		},
 		"remark-lint-table-pipes": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-table-pipes/-/remark-lint-table-pipes-2.0.0.tgz",
-			"integrity": "sha512-qGIttPFNT+19BEDz2JJWQtJIClFNIpg+XVw6ruX9LSR7xdo5QG9uARG4XS2EGUQQ7fiLIxQYb8g2dHwuXGbfmA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-table-pipes/-/remark-lint-table-pipes-2.0.1.tgz",
+			"integrity": "sha512-ZdR9rj1BZYXHPXFk3Gnb4agwL+CtO/SojhHua4iRBx1WCQElCeZS3M9naRrE41+2QSNkKnytgGZJzyAlm2nFGQ==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2860,9 +2868,9 @@
 			}
 		},
 		"remark-lint-unordered-list-marker-style": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/remark-lint-unordered-list-marker-style/-/remark-lint-unordered-list-marker-style-2.0.0.tgz",
-			"integrity": "sha512-s+ZiBgBDbIiScPPxWG/r2E/4YY+xP6EFLsLXPV/uPx7JqegIP/4+MAPi7Nz2zLmnQ2eekssZrEXma3uDb/dE1Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/remark-lint-unordered-list-marker-style/-/remark-lint-unordered-list-marker-style-2.0.1.tgz",
+			"integrity": "sha512-8KIDJNDtgbymEvl3LkrXgdxPMTOndcux3BHhNGB2lU4UnxSpYeHsxcDgirbgU6dqCAfQfvMjPvfYk19QTF9WZA==",
 			"dev": true,
 			"requires": {
 				"unified-lint-rule": "^1.0.0",
@@ -2882,9 +2890,9 @@
 			}
 		},
 		"remark-parse": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.2.tgz",
-			"integrity": "sha512-eMI6kMRjsAGpMXXBAywJwiwAse+KNpmt+BK55Oofy4KvBZEqUDj6mWbGLJZrujoPIPPxDXzn3T9baRlpsm2jnQ==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
+			"integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
 			"dev": true,
 			"requires": {
 				"ccount": "^1.0.0",
@@ -2906,9 +2914,9 @@
 			}
 		},
 		"remark-stringify": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.0.0.tgz",
-			"integrity": "sha512-cABVYVloFH+2ZI5bdqzoOmemcz/ZuhQSH6W6ZNYnLojAUUn3xtX7u+6BpnYp35qHoGr2NFBsERV14t4vCIeW8w==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
+			"integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
 			"dev": true,
 			"requires": {
 				"ccount": "^1.0.0",
@@ -3237,9 +3245,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
 			"dev": true
 		},
 		"split-string": {
@@ -3360,9 +3368,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -3403,9 +3411,9 @@
 			}
 		},
 		"tlds": {
-			"version": "1.207.0",
-			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.207.0.tgz",
-			"integrity": "sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==",
+			"version": "1.210.0",
+			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.210.0.tgz",
+			"integrity": "sha512-5bzt4JE+NlnwiKpVW9yzWxuc44m+t2opmPG+eSKDp5V5qdyGvjMngKgBb5ZK8GiheQMbRTCKpRwFJeIEO6pV7Q==",
 			"dev": true
 		},
 		"to-object-path": {
@@ -3515,9 +3523,9 @@
 			}
 		},
 		"unified": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-			"integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
+			"integrity": "sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==",
 			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
@@ -3543,9 +3551,9 @@
 			}
 		},
 		"unified-lint-rule": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.5.tgz",
-			"integrity": "sha512-jOPr/fx8lTzqszEfh46p99jUMqgPlIZ8rNKllEepumISvgfj9lUq1c7BSpVihr0L1df3lkjVHAThRPS7dIyjYg==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.6.tgz",
+			"integrity": "sha512-YPK15YBFwnsVorDFG/u0cVVQN5G2a3V8zv5/N6KN3TCG+ajKtaALcy7u14DCSrJI+gZeyYquFL9cioJXOGXSvg==",
 			"dev": true,
 			"requires": {
 				"wrapped": "^1.0.1"
@@ -3755,13 +3763,13 @@
 			}
 		},
 		"unist-util-find-all-between": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-between/-/unist-util-find-all-between-2.0.0.tgz",
-			"integrity": "sha512-tSCQ5dMoAbVQCf7nz1Bt2ejopAF2QZxnflCNG1hLgj+fvY0Y23idCbU0+yGbtk9vQSWGzyIhjJG1ZM1TfPf3Dg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-find-all-between/-/unist-util-find-all-between-2.1.0.tgz",
+			"integrity": "sha512-OCCUtDD8UHKeODw3TPXyFDxPCbpgBzbGTTaDpR68nvxkwiVcawBqMVrokfBMvUi7ij2F5q7S4s4Jq5dvkcBt+w==",
 			"dev": true,
 			"requires": {
 				"unist-util-find": "^1.0.1",
-				"unist-util-is": "^4.0.0"
+				"unist-util-is": "^4.0.2"
 			}
 		},
 		"unist-util-generated": {
@@ -3845,9 +3853,9 @@
 			}
 		},
 		"unist-util-visit": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
-			"integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+			"integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
 			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.0",
@@ -3856,9 +3864,9 @@
 			}
 		},
 		"unist-util-visit-parents": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
-			"integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz",
+			"integrity": "sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==",
 			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.0",
@@ -3959,9 +3967,9 @@
 			}
 		},
 		"vfile": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
-			"integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+			"integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
 			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.0",
@@ -3980,9 +3988,9 @@
 			}
 		},
 		"vfile-location": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
-			"integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.1.0.tgz",
+			"integrity": "sha512-FCZ4AN9xMcjFIG1oGmZKo61PjwJHRVA+0/tPUP2ul4uIwjGGndIxavEMRpWn5p4xwm/ZsdXp9YNygf1ZyE4x8g==",
 			"dev": true
 		},
 		"vfile-message": {
@@ -4068,14 +4076,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"bump": "git tag \"$(date -u +%Y.%m_${MICRO:-1})\""
 	},
 	"devDependencies": {
-		"awesome-lint": "^0.13.0"
+		"awesome-lint": "^0.15.0"
 	},
 	"private": true
 }


### PR DESCRIPTION
Additionally fixes a duplicate link issue raised by new `remark-lint:double-link` rule.
